### PR TITLE
Remove self-closing tag in custom button example

### DIFF
--- a/components/sign-in/sign-in-button.md
+++ b/components/sign-in/sign-in-button.md
@@ -29,7 +29,7 @@ import { SignInButton } from "@clerk/nextjs";
 ### Custom button, open a modal
 
 ```xml
-<SignInButton mode="modal"/>
+<SignInButton mode="modal">
   <button className="btn">
     Sign in
   </button>


### PR DESCRIPTION
In the custom button component example, the tag is self-closed, but should be closed with an associated `</SignInButton>`.