### PR TITLE
feat: Add last active redirect on dashboard links

### DIFF
--- a/components/sign-in/redirect-to-sign-in.md
+++ b/components/sign-in/redirect-to-sign-in.md
@@ -6,7 +6,7 @@ description: Navigate immediately to the sign-in URL
 
 ## Overview
 
-Rendering a `<RedirectToSignIn/>` component will navigate to the sign in URL which has been configured in your application instance. You can find the configuration in the [Clerk Dashboard](https://dashboard.clerk.dev). Go to your application, select your instance, then go to **Paths**.
+Rendering a `<RedirectToSignIn/>` component will navigate to the sign in URL which has been configured in your application instance. You can find the configuration on the [Paths page](https://dashboard.clerk.dev/last-active?path=paths).
 
 The behavior will be just like a server-side (3xx) redirect, and will override the current location in the history stack.
 

--- a/components/sign-in/sign-in.md
+++ b/components/sign-in/sign-in.md
@@ -8,7 +8,7 @@ description: Full-featured UI for signing users in your application.
 
 The `<SignIn/>` component renders a UI for signing in users. Most of the times, the `<SignIn/>` component is all you need for completing sign ins. It supports any authentication scheme, from [Email/password authentication](../../popular-guides/email-and-password.md), and [Passwordless](../../popular-guides/passwordless-authentication.md), to [Social Login (OAuth)](../../popular-guides/social-login-oauth.md) and [Multi-factor verification](../../popular-guides/multi-factor-authentication.md).
 
-The contents and functionality of the `<SignIn/>` component are controlled for the most part by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.dev). Your instance settings also allow for customization of the look and feel of the `<SignIn/>` component.
+The contents and functionality of the `<SignIn/>` component are controlled for the most part by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.dev/last-active). Your instance settings also allow for customization of the look and feel of the `<SignIn/>` component.
 
 You can further customize your `<SignIn/>` component by passing additional [properties](sign-in.md#props) at the time of rendering.
 
@@ -22,7 +22,7 @@ Here's an example of what the component looks like once it's rendered.
 Make sure you've followed the installation guide for [Clerk React](../../reference/clerk-react/installation.md) or [ClerkJS](../../reference/clerkjs/installation.md) before running the snippets below.
 {% endhint %}
 
-Once you set up the desired functionality and look and feel for the `<SignIn/>` component, all that's left is to render it inside your page. The default rendering is simple but powerful enough to cover most use-cases. The authentication and display (look and feel) configuration that you've set up in your [Clerk Dashboard](https://dashboard.clerk.dev) will work out of the box.
+Once you set up the desired functionality and look and feel for the `<SignIn/>` component, all that's left is to render it inside your page. The default rendering is simple but powerful enough to cover most use-cases. The authentication and display (look and feel) configuration that you've set up in your [Clerk Dashboard](https://dashboard.clerk.dev/last-active) will work out of the box.
 
 {% tabs %}
 {% tab title="Clerk React" %}
@@ -229,4 +229,4 @@ window.Clerk.openSignIn({
 
 ## Customization
 
-The `<SignIn/>` component can be highly customized through the Instance settings in the [Clerk Dashboard](https://dashboard.clerk.dev). This document will be updated soon with all necessary details.
+The `<SignIn/>` component can be highly customized through the Instance settings on the [Theme page](https://dashboard.clerk.dev/last-active?path=customization/theme). This document will be updated soon with all necessary details.

--- a/components/sign-up/redirect-to-sign-up.md
+++ b/components/sign-up/redirect-to-sign-up.md
@@ -6,7 +6,7 @@ description: Navigate immediately to the sign-up URL
 
 ## Overview
 
-Rendering a `<RedirectToSignUp/>` component will navigate to the sign up URL which has been configured in your application instance. You can find the configuration in the [Clerk Dashboard](https://dashboard.clerk.dev). Go to your application, select your instance, then go to **Paths**.&#x20;
+Rendering a `<RedirectToSignUp/>` component will navigate to the sign up URL which has been configured in your application instance. You can find the configuration on the [Paths page](https://dashboard.clerk.dev/last-active?path=paths).
 
 The behavior will be just like a server-side (3xx) redirect, and will override the current location in the history stack.
 

--- a/components/sign-up/sign-up.md
+++ b/components/sign-up/sign-up.md
@@ -24,7 +24,7 @@ Make sure you've followed the installation guide for [Clerk React](../../referen
 
 ### Mounting in your app
 
-Once you set up the desired functionality and look and feel for the `<SignIn/>` component, all that's left is to render it inside your page. The default rendering is simple but powerful enough to cover most use-cases. The authentication and display (look and feel) configuration that you've set up in your [Clerk Dashboard](https://dashboard.clerk.dev) will work out of the box.
+Once you set up the desired functionality and look and feel for the `<SignIn/>` component, all that's left is to render it inside your page. The default rendering is simple but powerful enough to cover most use-cases. The authentication and display (look and feel) configuration that you've set up in your [Clerk Dashboard](https://dashboard.clerk.dev/last-active) will work out of the box.
 
 {% tabs %}
 {% tab title="Clerk React" %}
@@ -230,4 +230,4 @@ const SignUpButton = () => {
 
 ## Customization
 
-The `<SignUp/>` component can be highly customized through the Instance settings in the [Clerk Dashboard](https://dashboard.clerk.dev). This document will be updated soon with all necessary details.
+The `<SignUp/>` component can be highly customized through the Instance settings on the [Theme page](https://dashboard.clerk.dev/last-active?path=customization/theme). This document will be updated soon with all necessary details.

--- a/components/user-button.md
+++ b/components/user-button.md
@@ -26,7 +26,7 @@ Make sure you've followed the installation guide for [Clerk React](../reference/
 
 ### Mounting in your app
 
-Once you set up the desired functionality and look and feel for the `<UserButton/>` component, all that's left is to render it inside your page. The default rendering is simple but powerful enough to cover most use-cases. The  theme configuration (look and feel) that you've set up in your [Clerk Dashboard](https://dashboard.clerk.dev) will work out of the box.
+Once you set up the desired functionality and look and feel for the `<UserButton/>` component, all that's left is to render it inside your page. The default rendering is simple but powerful enough to cover most use-cases. The theme configuration (look and feel) that you've set up on the [Theme page](https://dashboard.clerk.dev/last-active?path=customization/theme) will work out of the box.
 
 {% tabs %}
 {% tab title="Clerk React" %}
@@ -100,4 +100,4 @@ export default App;
 
 ## Customization
 
-The `<UserButton/>` component can be highly customized through the Instance settings in the [Clerk Dashboard](https://dashboard.clerk.dev). This document will be updated soon with all necessary details.
+The `<UserButton/>` component can be highly customized through the Instance settings on the [Theme page](https://dashboard.clerk.dev/last-active?path=customization/theme). This document will be updated soon with all necessary details.

--- a/components/user-profile/redirect-to-user-profile.md
+++ b/components/user-profile/redirect-to-user-profile.md
@@ -6,7 +6,7 @@ description: Navigate to the user profile URL.
 
 ## Overview
 
-Rendering a `<RedirectToUserProfile/>` component will navigate to the user profile URL which has been configured in your application instance. You can find the configuration in the [Clerk Dashboard](https://dashboard.clerk.dev). Go to your application, select your instance, then go to **Paths**.
+Rendering a `<RedirectToUserProfile/>` component will navigate to the user profile URL which has been configured in your application instance. You can find the configuration on the [Paths page](https://dashboard.clerk.dev/last-active?path=paths).
 
 This component will use the custom `navigate` function from the [`<ClerkProvider/>` component](../../reference/clerk-react/clerkprovider.md) if one is given - otherwise it will trigger a full page reload with the new URL location.
 

--- a/components/user-profile/user-profile.md
+++ b/components/user-profile/user-profile.md
@@ -28,7 +28,7 @@ Make sure you've followed the installation guide for [Clerk React](../../referen
 
 ### Mounting in your app
 
-Once you set up the desired functionality and look and feel for the `<UserProfile/>` component, all that's left is to render it inside your page. The default rendering is simple but powerful enough to cover most use-cases. The  theme configuration (look and feel) that you've set up in your [Clerk Dashboard](https://dashboard.clerk.dev) will work out of the box.
+Once you set up the desired functionality and look and feel for the `<UserProfile/>` component, all that's left is to render it inside your page. The default rendering is simple but powerful enough to cover most use-cases. The  theme configuration (look and feel) that you've set up on the [Theme page](https://dashboard.clerk.dev/last-active?path=customization/theme) will work out of the box.
 
 {% tabs %}
 {% tab title="Clerk React" %}
@@ -250,4 +250,4 @@ For more information, see [Routing](broken-reference).
 
 ## Customization
 
-The `<UserProfile/>` component can be highly customized through the Instance settings in the [Clerk Dashboard](https://dashboard.clerk.dev). This document will be updated soon with all necessary details.
+The `<UserProfile/>` component can be highly customized through the Instance settings on the [Theme page](https://dashboard.clerk.dev/last-active?path=customization/theme). This document will be updated soon with all necessary details.

--- a/get-started/create-react-app.md
+++ b/get-started/create-react-app.md
@@ -69,9 +69,7 @@ yarn add @clerk/clerk-react
 {% endtab %}
 {% endtabs %}
 
-Now, we need to set the `CLERK_FRONTEND_API` environment variable. Go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your **Application** and copy the **Frontend API Key** field from the Development instance Home page.
-
-![Home page with Frontend API key highlighted](<../.gitbook/assets/home - frontend api key highlighted.png>)
+Now, we need to set the `CLERK_FRONTEND_API` environment variable. Go to the [API Keys page](https://dashboard.clerk.dev/last-active?path=api-keys) and copy the **Frontend API Key** field.
 
 Then, create a file named `.env.local` in your application root. Any variables inside this file with the `REACT_APP_` prefix will be accessible in your React code via `process.env.REACT_APP_VAR_NAME`. Create a `REACT_APP_CLERK_FRONTEND_API` variable and set it to the `Frontend API` you copied earlier:
 

--- a/get-started/get-started-with-gatsby.md
+++ b/get-started/get-started-with-gatsby.md
@@ -45,9 +45,7 @@ yarn add gatsby-plugin-clerk @clerk/clerk-react
 {% endtab %}
 {% endtabs %}
 
-As a next step, you'll need the `frontendApi` key of your Clerk application. To find it, go to the  [Clerk Dashboard](https://dashboard.clerk.dev), choose the application and the instance you're working on, and locate the key on the **Home** tab.
-
-![Home page with Frontend API key highlighted](<../.gitbook/assets/home - frontend api key highlighted.png>)
+As a next step, you'll need the `frontendApi` key of your Clerk application. To find it, go to the [API Keys page](https://dashboard.clerk.dev/last-active?path=api-keys) and copy the **Frontend API Key** field.
 
 Now, let's configure the plugin on `gatsby-config.js.`
 

--- a/get-started/get-started-with-web3.md
+++ b/get-started/get-started-with-web3.md
@@ -67,9 +67,7 @@ yarn add @clerk/nextjs
 {% endtab %}
 {% endtabs %}
 
-Now, we need to set the `CLERK_FRONTEND_API` environment variable. Go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your **Application**, **** copy the **Frontend API Key** field from the Development instance Home page.
-
-![Home page with Frontend API key highlighted](<../.gitbook/assets/home - frontend api key highlighted.png>)
+Now, we need to set the `CLERK_FRONTEND_API` environment variable. Go to the [API Keys page](https://dashboard.clerk.dev/last-active?path=api-keys) and copy the **Frontend API Key** field.
 
 Then, create a file named `.env.local` in your application root. Any variables inside this file with the `NEXT_PUBLIC_` prefix will be accessible in your Next.js code via `process.env.NEXT_PUBLIC_VAR_NAME`. Create a `NEXT_PUBLIC_CLERK_FRONTEND_API` variable and set it to the `Frontend API` you copied earlier:
 

--- a/get-started/nextjs-api.md
+++ b/get-started/nextjs-api.md
@@ -14,9 +14,7 @@ This guide assumes you have properly completed your Next.js [frontend setup](nex
 
 Create a file named **.env.local** in your application root if it doesn't exist already. Any variables inside this file will be accessible in your backend with **process.env.VARIABLE\_NAME**.
 
-Now, we need to set the `CLERK_API_KEY` environment variable. Go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your **Application**, **** copy the **Backend API Key** field from the Development instance Home page.
-
-![Home page with Backend API key highlighted](<../.gitbook/assets/home - backend api key highlighted.png>)
+Now, we need to set the `CLERK_API_KEY` environment variable. Go to the [API Keys page](https://dashboard.clerk.dev/last-active?path=api-keys) and copy the **Backend API Key** field.
 
 {% code title=".env.local" %}
 ```jsx

--- a/get-started/nextjs.md
+++ b/get-started/nextjs.md
@@ -65,9 +65,7 @@ yarn add @clerk/nextjs
 {% endtab %}
 {% endtabs %}
 
-Now, we need to set the `CLERK_FRONTEND_API` environment variable. Go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your **Application**, **** copy the **Frontend API Key** field from the Development instance Home page:
-
-![Home page with Frontend API key highlighted](<../.gitbook/assets/home - frontend api key highlighted.png>)
+Now, we need to set the `CLERK_FRONTEND_API` environment variable. Go to the [API Keys page](https://dashboard.clerk.dev/last-active?path=api-keys) and copy the **Frontend API Key** field.
 
 Then, create a file named `.env.local` in your application root. Any variables inside this file with the `NEXT_PUBLIC_` prefix will be accessible in your Next.js code via `process.env.NEXT_PUBLIC_VAR_NAME`. Create a `NEXT_PUBLIC_CLERK_FRONTEND_API` variable and set it to the `Frontend API` you copied earlier:
 

--- a/get-started/redwoodjs.md
+++ b/get-started/redwoodjs.md
@@ -16,9 +16,9 @@ This guide will walk you through the necessary steps to integrate Clerk as the e
 
 ### Getting started
 
-The first step is to create a new Clerk application from your Clerk Dashboard if you haven’t done so already. You can choose whichever authentication strategy and social login providers you prefer. For more information, check out our [Set up your application](../popular-guides/setup-your-application.md) guide.
+The first step is to create a new Clerk application from your [Clerk Dashboard](https://dashboard.clerk.dev) if you haven’t done so already. You can choose whichever authentication strategy and social login providers you prefer. For more information, check out our [Set up your application](../popular-guides/setup-your-application.md) guide.
 
-After your Clerk application has been created, scroll down to the **Connect your application** section of the dashboard and locate your API keys.
+Now, we need to retrieve your API keys from the [API Keys page](https://dashboard.clerk.dev/last-active?path=api-keys).
 
 In your Redwood app directory, create a `.env` file (if one does not currently exist) and set the following environment variables to the respective values from your Clerk dashboard:
 

--- a/get-started/remix.md
+++ b/get-started/remix.md
@@ -41,9 +41,7 @@ Once you have a Remix app ready, you need to install the Clerk Remix SDK. This w
 npm install @clerk/remix@next
 ```
 
-Now, we need to retrieve your Backend API Key from the [Clerk Dashboard](https://dashboard.clerk.dev). Select your **Application**, **** and find the value on the Development instance Home page.
-
-![Home page with Frontend API key highlighted](<../.gitbook/assets/home - frontend api key highlighted.png>)
+Now, we need to retrieve your Backend API Key from the [API Keys page](https://dashboard.clerk.dev/last-active?path=api-keys).
 
 Remix allows developers to set environment variables by creating a `.env` file in their application root. Add Clerk's environment variables as follows:
 

--- a/integrations/bubble.io-beta.md
+++ b/integrations/bubble.io-beta.md
@@ -113,10 +113,10 @@ To show the _UserButton_, add a new workflow using a_"Clerk loaded with user"_ e
 ## Frequently Asked Questions
 
 * **Where can I manage my application's users?**\
-  ****Users can be managed from the [Clerk Dashboard](https://dashboard.clerk.dev) in the **Users** section.\
+  ****Users can be managed from the [Users page](https://dashboard.clerk.dev/last-active?path=users).\
 
 * **Can I change the Clerk interface theme to match my application ?**\
-  ****Yes! Navigate to **Settings → Theme** in the [Clerk Dashboard](https://dashboard.clerk.dev) for your instance for complete customizability.  _Don't forget to press the Apply changes button!_
+  ****Yes! Navigate to the [Theme page](https://dashboard.clerk.dev/last-active?path=customization/theme) for complete customizability.  _Don't forget to press the Apply changes button!_
 * **Can I migrate all my existing bubble.io users to Clerk ?**\
   ****Yes! [Contact us](https://clerk.dev/support) and we can help you migrate your existing user base.
 

--- a/integrations/firebase.md
+++ b/integrations/firebase.md
@@ -8,9 +8,7 @@ We have an example application showcasing how to integrate Clerk with Firebase, 
 
 To enable the integration, you will need to provide Clerk with the required Firebase configuration attributes depending on the Firebase features you would require authenticated user access to.
 
-To get started, turn on the Firebase integration in the [dashboard](https://dashboard.clerk.dev):
-
-**Your Application & instance → Integrations → Firebase**
+To get started, turn on the Firebase integration on the [Integrations page](https://dashboard.clerk.dev/last-active?path=integrations).
 
 ## 2. Integration configuration
 

--- a/integrations/google-analytics.md
+++ b/integrations/google-analytics.md
@@ -10,9 +10,7 @@ This integration enables Clerk to send  user authentication events to the config
 
 To enable the integration, you will need to provide Clerk with the required Google Analytics configuration attributes depending on the type of Google Analytics property. **We support both Universal Analytics and Google Analytics 4 properties.**
 
-To get started, turn on the Google Analytics integration in the [dashboard](https://dashboard.clerk.dev):
-
-**Your Application  and instance → Integrations → Google Analytics**
+To get started, turn on the Google Analytics integration on the [Integrations page](https://dashboard.clerk.dev/last-active?path=integrations).
 
 ![](../.gitbook/assets/screely-1639509148300.png)
 

--- a/popular-guides/email-and-password.md
+++ b/popular-guides/email-and-password.md
@@ -25,9 +25,7 @@ To keep your users safe, Clerk follows a "secure-by-default" policy, and we foll
 
 ## Configuration
 
-The first thing you need to do is enable email address and password-based authentication in your Clerk instance.
-
-From the [Clerk Dashboard](https://dashboard.clerk.dev), select your instance and head over to **Authentication** > **Standard Form Fields**.&#x20;
+The first thing you need to do is enable email address and password-based authentication on the [Email, Phone, Username page](https://dashboard.clerk.dev/last-active?path=user-authentication/email-phone-username).
 
 Select **Email address** for your contact information and **Password** as your authentication strategy.
 

--- a/popular-guides/magic-links.md
+++ b/popular-guides/magic-links.md
@@ -46,11 +46,9 @@ We take care of the boring stuff, like efficient polling, secure session managem
 
 ## Configuration
 
-Magic link authentication can be configured through the [Clerk Dashboard](https://dashboard.clerk.dev). Go to your instance, then **Authentication > Standard Form Fields.** Simply choose **Passwordless** as the authentication strategy.
+Magic link authentication can be configured on the [Email, Phone, Username page](https://dashboard.clerk.dev/last-active?path=user-authentication/email-phone-username). Simply choose **Email verification link** as the authentication strategy.
 
-![](../.gitbook/assets/screely-1639505701741.png)
-
-Don't forget that you also need to make sure you've configured your application instance to request the user's email address. Users can receive magic links only via email messages. Make sure you select one of the following options;  **Email address** or **Email address OR phone number**.&#x20;
+Don't forget that you also need to make sure you've configured your application instance to request the user's email address. Users can receive magic links only via email messages. Make sure you select the **Email address** option.&#x20;
 
 {% hint style="warning" %}
 Don't forget to click on the **Apply Changes** button at the bottom of the page once you're done configuring your instance.
@@ -131,7 +129,7 @@ Similarly, there's a [\<SignIn />](../components/sign-in/sign-in.md) pre-built c
 
 On the other hand for adding and verifying email addresses to a user's profile, Clerk offers a customizable [\<UserProfile />](../components/user-profile/user-profile.md) pre-built component.
 
-Note that you don't need to pass any special options to the pre-built **\<SignUp />,** **\<SignIn />** and **\<UserProfile />** components. Magic link authentication/verification will just work, since you already configured it through the Clerk [dashboard](https://dashboard.clerk.dev).
+Note that you don't need to pass any special options to the pre-built **\<SignUp />,** **\<SignIn />** and **\<UserProfile />** components. Magic link authentication/verification will just work, since you already configured it on the [Email, Phone, Username page](https://dashboard.clerk.dev/last-active?path=user-authentication/email-phone-username).
 
 ### Sign up <a href="#clerk-components-sign-up" id="clerk-components-sign-up"></a>
 

--- a/popular-guides/multi-factor-authentication.md
+++ b/popular-guides/multi-factor-authentication.md
@@ -27,7 +27,7 @@ Interested in single-factor authentication? Check out our guides on [password-ba
 
 ## Configuration
 
-There's two parts to enabling multi-factor authentication for your application. First, you need to apply the appropriate configuration setting in the [Clerk Dashboard](https://dashboard.clerk.dev). Then, registered users need to turn on MFA for their own account through their **User Profile** page.
+There's two parts to enabling multi-factor authentication for your application. First, you need to apply the appropriate configuration setting on the [Multi-factor authentication page](https://dashboard.clerk.dev/last-active?path=user-authentication/multi-factor). Then, registered users need to turn on MFA for their own account through their **User Profile** page.
 
 ### Dashboard configuration
 
@@ -148,7 +148,7 @@ You can leverage [Clerk Components](broken-reference) to easily add multi-factor
 
 Clerk provides a [\<SignIn />](../components/sign-in/sign-in.md) pre-built component that renders a sign in form and takes care of authenticating users and creating a session.
 
-Note that you don't need to pass any special options to the pre-built **\<SignIn />** component. Multi-factor authentication will just work once users enable it under their profile settings, since it's already been configured through the [Clerk Dashboard](https://dashboard.clerk.dev).
+Note that you don't need to pass any special options to the pre-built **\<SignIn />** component. Multi-factor authentication will just work once users enable it under their profile settings, since it's already been configured on the [Multi-factor authentication page](https://dashboard.clerk.dev/last-active?path=user-authentication/multi-factor).
 
 {% tabs %}
 {% tab title="Clerk React" %}

--- a/popular-guides/passwordless-authentication.md
+++ b/popular-guides/passwordless-authentication.md
@@ -29,11 +29,9 @@ Looking for 2FA? Check out our [Multi-factor authentication](multi-factor-authen
 
 ## Configuration
 
-Passwordless authentication can be configured through the [Clerk Dashboard](https://dashboard.clerk.dev). Go to your instance, then **Authentication** > **Standard Form Fields.** Simply choose **Passwordless** as the authentication strategy and click the cog to select One-time codes.
+Passwordless authentication can be configured on the [Email, Phone, Username page](https://dashboard.clerk.dev/last-active?path=user-authentication/email-phone-username). Simply choose **Email verification link**, **Email verification code** or **SMS verification code** as the authentication strategy.
 
-![](../.gitbook/assets/screely-1639505933346.png)
-
-Don't forget that you also need to make sure you've configured your application instance to request the user's contact information.  Users can receive one-time codes via either an email address or a phone number. Make sure you select one of the following options;  **Email address**, **Phone number** or **Email address OR phone number**.&#x20;
+Don't forget that you also need to make sure you've configured your application instance to request the user's contact information.  Users can receive one-time codes via either an email address or a phone number. Make sure you select one of the following options: **Email address** or **Phone number**.&#x20;
 
 For the rest of this guide, we'll use the **Phone number** option.
 

--- a/popular-guides/popular-guides-multi-session-applications.md
+++ b/popular-guides/popular-guides-multi-session-applications.md
@@ -35,7 +35,7 @@ Looking for more information on session management? Check out our [detailed guid
 
 The first thing you need to do is to enable the multi-session feature in your Clerk instance.
 
-From the [Clerk Dashboard](https://dashboard.clerk.dev), select your application and instance, navigate to **Security** > **Sessions** and choose **Multi-session handling**.
+Go to the [Sessions page](https://dashboard.clerk.dev/last-active?path=sessions) and enable **Multi-session handling**.
 
 ![](../.gitbook/assets/screely-1639506808306.png)
 

--- a/popular-guides/social-login-oauth.md
+++ b/popular-guides/social-login-oauth.md
@@ -27,7 +27,7 @@ The easiest way to add social login is by using our prebuilt [Clerk Hosted Pages
 
 ## Configuration
 
-To enable a social login provider, go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your **Application**, **** and navigate to **Authentication** **** ➜  **Social Login**
+To enable a social login provider, go to the [Social Login page](https://dashboard.clerk.dev/last-active?path=authentication/social).
 
 Social login configuration consists of the following steps:
 
@@ -175,7 +175,7 @@ To further customize your sign up and sign in pages, you can use [Clerk Componen
 
 Clerk provides the  [\<SignUp/>](../components/sign-up/sign-up.md)  and [\<SignIn/>](../components/sign-in/sign-in.md) prebuilt components that render a conversion-optimized sign up and sign form.
 
-Note that you don't need to pass any special props to the \<SignUp/> and \<SignIn/> components, it will automatically display the configuration you chose in the [Clerk Dashboard](https://dashboard.clerk.dev).
+Note that you don't need to pass any special props to the \<SignUp/> and \<SignIn/> components, it will automatically display the configuration you chose on the [Social Login page](https://dashboard.clerk.dev/last-active?path=authentication/social).
 
 When using social login, the sign up and sign in flows are equivalent.  If a user doesn't have an account and tries to sign in, an account will be made for them, and vice versa.
 
@@ -258,7 +258,7 @@ And you're done! 🎉
 
 The above examples don't require any specific routes to be defined, they automatically use the [Clerk Hosted Pages](broken-reference) to handle the required OAuth redirects. If you prefer having the mounted \<SignIn/> and \<SignUp/> components handle the OAuth redirects instead, you need to follow some additional steps:
 
-From the [Clerk Dashboard](https://dashboard.clerk.dev), select your **Application**, navigate to **Instance** ➜  **Paths.** Change the **Sign Up URL** to `/sign-up` and the **Sign In URL** to `/sign-in`.
+On the [Paths page](https://dashboard.clerk.dev/last-active?path=paths), change the **Sign Up URL** to `/sign-up` and the **Sign In URL** to `/sign-in`.
 
 Finally, in your app define a `/sign-up` route that renders the \<SignUp /> component. Similarly, define a `/sign-in`route that renders the \<SignIn /> component as shown in the following example. Refer to the [\<SignIn/>](../components/sign-in/sign-in.md) and [\<SignUp/>](../components/sign-up/sign-up.md) docs to learn more about the `routing` and `path` props.
 

--- a/popular-guides/sync-data-to-your-backend.md
+++ b/popular-guides/sync-data-to-your-backend.md
@@ -26,7 +26,7 @@ Given the asynchronous nature of webhooks, they might not fit in every use case 
 
 Clerk provides webhook support by integrating with [Svix](https://www.svix.com).&#x20;
 
-The Svix integration can be enabled through [Clerk Dashboard](https://dashboard.clerk.dev), by going to your instance and then to **Integrations** > **Svix**. Use the toggle button to enable/disable the integration.
+The Svix integration can be enabled on the [Integrations page](https://dashboard.clerk.dev/last-active?path=integrations). Use the toggle button to enable/disable the integration.
 
 ![](../.gitbook/assets/screely-1639507436297.png)
 

--- a/reference/backend-api-reference/sdks/ruby/getting-started.md
+++ b/reference/backend-api-reference/sdks/ruby/getting-started.md
@@ -22,7 +22,7 @@ $ gem install clerk-sdk-ruby
 
 ## Quick Start
 
-First, you need to get an API key for a Clerk instance. This is done via the [Clerk dashboard](https://dashboard.clerk.dev/applications).
+First, you need to get an API key for a Clerk instance. This is done on the [API Keys page](https://dashboard.clerk.dev/last-active?path=api-keys).
 
 Then you can instantiate a `Clerk::SDK` instance and access all [Backend API](../../) endpoints. Here's a quick example:
 

--- a/reference/clerk-expo.md
+++ b/reference/clerk-expo.md
@@ -38,7 +38,7 @@ Render a `<ClerkProvider/>` component at the root of your React app so that it i
 
 In order to use`<ClerkProvider/>` first you need to locate the entry point file of your React Native app. In Expo, this is usually your `src/App.js`.
 
-Replace the `frontendApi` prop with the [Frontend API](frontend-api-reference/) host found in your [Clerk Dashboard](https://dashboard.clerk.dev).
+Replace the `frontendApi` prop with the [Frontend API](frontend-api-reference/) host found on the [API Keys page](https://dashboard.clerk.dev/last-active?path=api-keys).
 
 ```jsx
 import React from "react";

--- a/reference/clerk-react/installation.md
+++ b/reference/clerk-react/installation.md
@@ -40,7 +40,7 @@ Render a `<ClerkProvider/>` component at the root of your React app so that it i
 
 In order to use`<ClerkProvider/>,` first you need to locate the entry point file of your React app. Usually this is your `src/index.js` (Create React App) or `pages/_app` (Next.js) file. In general, you're looking for the file where the `ReactDOM.render` function gets called.
 
-Replace the `frontendApi` prop with the [Frontend API](../frontend-api-reference/) host found in your [Clerk Dashboard](https://dashboard.clerk.dev).
+Replace the `frontendApi` prop with the [Frontend API](../frontend-api-reference/) host found on the [API Keys page](https://dashboard.clerk.dev/last-active?path=api-keys).
 
 {% tabs %}
 {% tab title="React" %}

--- a/reference/clerkjs/installation.md
+++ b/reference/clerkjs/installation.md
@@ -32,7 +32,7 @@ npm install @clerk/clerk-js
 yarn add @clerk/clerk-js
 ```
 
-Once you've installed the ClerkJS package, you first have to import it in your own code. The [Clerk object](clerk.md) constructor needs the [Frontend API](../frontend-api-reference/) URL as a parameter. You can find the URL in your **Instance Home** page in the [Clerk Dashboard](https://dashboard.clerk.dev).
+Once you've installed the ClerkJS package, you first have to import it in your own code. The [Clerk object](clerk.md) constructor needs the [Frontend API](../frontend-api-reference/) URL as a parameter. You can find the **Frontend API key** on the [API Keys page](https://dashboard.clerk.dev/last-active?path=api-keys).
 
 ```javascript
 import Clerk from "@clerk/clerk-js";
@@ -46,7 +46,7 @@ await clerk.load({
 
 ### Loading ClerkJS as a script
 
-You can also load ClerkJS with a `<script/>` tag in your website, straight from your [Frontend API](../frontend-api-reference/) URL. You can find the URL in your **Instance Home** page in the [Clerk Dashboard](https://dashboard.clerk.dev).
+You can also load ClerkJS with a `<script/>` tag in your website, straight from your [Frontend API](../frontend-api-reference/) URL. You can find the URL on the [API Keys page](https://dashboard.clerk.dev/last-active?path=api-keys).
 
 For security reasons, the ClerkJS library can only be loaded from the same domain. Make sure your website runs on the same domain as your Frontend API.
 

--- a/reference/frontend-api-reference/introduction.md
+++ b/reference/frontend-api-reference/introduction.md
@@ -2,7 +2,7 @@
 
 The **Frontend API** is built to be used from your frontend code. It is the same API that our pre-built UIs use.  If you need to augment your Sign in, Sign up, or User profile processes, this API is for you.   We follow a familiar [REST](https://en.wikipedia.org/wiki/Representational\_state\_transfer) style, so hopefully this API is clear.  You can always [reach out](https://www.clerk.dev/support) for help.
 
-The **Frontend API** is accessed via the Frontend API Domain listed in your [Dashboard](https://dashboard.clerk.dev). Navigate to your instance, then it will be in the **Home** section.
+The **Frontend API key** is found on the [API Keys page](https://dashboard.clerk.dev/last-active?path=api-keys).
 
 In development, the URL will follow the following pattern:
 
@@ -16,7 +16,7 @@ All requests accept form-encoded request bodies, and respond with a JSON-encoded
 
 ## Frontend API Configuration
 
-All configuration for the frontend happens in the [Dashboard](https://dashboard.clerk.dev).  Navigate to your instance, then to **Authentication** to see and modify these settings.
+All configuration for the frontend happens in the [Dashboard](https://dashboard.clerk.dev/last-active). Navigate to your instance, then to **User & Authentication** to see and modify these settings.
 
 The **User management** settings you select _will modify certain parts_ of the **Frontend API**.
 

--- a/reference/social-login-reference/discord.md
+++ b/reference/social-login-reference/discord.md
@@ -27,7 +27,7 @@ First, you need to register a new OAuth Discord app at the [Discord Developer Po
 
 ![Creating an OAuth Discord app](../../.gitbook/assets/discord-create-app.png)
 
-Set a name for your new application and click create. Now that your application has been created, from the left side panel click on **OAuth2**, this is where you also need to add your **Redirect URL.** Go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your application **** and instance and go to **Authentication -> Social Login**. Click the **Manage connection** button under the Discord provider and copy the **Authorized redirect URI**. Paste the value into the **Redirect** input and save the changes.
+Set a name for your new application and click create. Now that your application has been created, from the left side panel click on **OAuth2**, this is where you also need to add your **Redirect URL.** Go to the [Social Login page](https://dashboard.clerk.dev/last-active?path=authentication/social) and enable Discord. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **Redirect** input and save the changes.
 
 Once all the above are complete, copy the **Client ID** and **Client Secret.** Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/reference/social-login-reference/dropbox.md
+++ b/reference/social-login-reference/dropbox.md
@@ -27,7 +27,7 @@ First, you need to register a new OAuth Dropbox app at the [Dropbox App Console]
 
 ![Creating an OAuth Dropbox app](../../.gitbook/assets/oauth\_dropbox\_create\_app.png)
 
-First you need to choose the API type, the App's type of access and to set a name for your new application. You also need to add the **OAuth Redirect URLs.** Go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your application **** and instance and go to **Authentication -> Social Login**. Click the **Manage connection** button under the Twitch provider and copy the **Authorized redirect URI**. Paste the value into the **OAuth Redirect URIs** input and click create.
+First you need to choose the API type, the App's type of access and to set a name for your new application. You also need to add the **OAuth Redirect URLs.** Go to the [Social Login page](https://dashboard.clerk.dev/last-active?path=authentication/social) and enable Dropbox. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **OAuth Redirect URIs** input and click create.
 
 Once all the above are complete, copy the **Client ID** and **Client Secret.** Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/reference/social-login-reference/github.md
+++ b/reference/social-login-reference/github.md
@@ -1,40 +1,40 @@
 ---
-description: How to setup social login with Github
+description: How to setup social login with GitHub
 ---
 
-# Github
+# GitHub
 
 ## Overview
 
-Adding social login with Github to your app with Clerk is simple -  you only need to set the **Client ID**, **Client Secret** and **Authorized redirect URI** in your instance settings.
+Adding social login with GitHub to your app with Clerk is simple -  you only need to set the **Client ID**, **Client Secret** and **Authorized redirect URI** in your instance settings.
 
 To make the development flow as smooth as possible, Clerk uses preconfigured shared OAuth credentials and redirect URIs for development instances - no other configuration is needed.&#x20;
 
-For production instances, you will need to generate your own Client ID and Client secret using your Github account.
+For production instances, you will need to generate your own Client ID and Client secret using your GitHub account.
 
 {% hint style="info" %}
-The purpose of this guide is to help you create a Github account and a Github OAuth app - if you're looking for step-by-step instructions using Clerk to add social login (OAuth) to your application, follow the [Social login (OAuth)](../../popular-guides/social-login-oauth.md) guide.
+The purpose of this guide is to help you create a GitHub account and a GitHub OAuth app - if you're looking for step-by-step instructions using Clerk to add social login (OAuth) to your application, follow the [Social login (OAuth)](../../popular-guides/social-login-oauth.md) guide.
 {% endhint %}
 
 ## Before you start
 
 * You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev). For more information, check out our [Setup your application](../../popular-guides/setup-your-application.md) guide.
-* You need to have a Github account. To create one, [click here](https://github.com/signup) .
+* You need to have a GitHub account. To create one, [click here](https://github.com/signup) .
 
-## Configuring Github social login
+## Configuring GitHub social login
 
-First, you need to register a new OAuth Github app. Follow the official Github instructions on [how to create an OAuth app](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app).
+First, you need to register a new OAuth GitHub app. Follow the official GitHub instructions on [how to create an OAuth app](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app).
 
-![Registering an OAuth Github app](../../.gitbook/assets/screely-1628426717069.png)
+![Registering an OAuth GitHub app](../../.gitbook/assets/screely-1628426717069.png)
 
-Go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your application **** and instance and go to **Authentication -> Social Login**. Click the **Manage connection** button under the Github provider and copy the **Authorized redirect URI**. Go back to the Github panel, paste the value into the **Authorization callback URL** field and compete the registration.
+Go to the [Social Login page](https://dashboard.clerk.dev/last-active?path=authentication/social) and enable GitHub. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Go back to the GitHub panel, paste the value into the **Authorization callback URL** field and complete the registration.
 
 Once registration is complete, you'll get redirected to project's admin panel. Click the **Generate a new client secret** button to get your new client secret. Then, copy the **Client ID** and **Client secret.** Go back to the Clerk Dashboard and paste them into the respective fields.
 
 ![Obtaining the Client ID and Client secret](../../.gitbook/assets/screely-1628427343412.png)
 
-Don't forget to click **Apply** in the Clerk dashboard. Social login with Github is now configured 🔥&#x20;
+Don't forget to click **Apply** in the Clerk dashboard. Social login with GitHub is now configured 🔥&#x20;
 
 ## Next Steps
 
-Learn how to add social login with Github to your Clerk application by following the [Social login (OAuth)](../../popular-guides/social-login-oauth.md) guide.
+Learn how to add social login with GitHub to your Clerk application by following the [Social login (OAuth)](../../popular-guides/social-login-oauth.md) guide.

--- a/reference/social-login-reference/gitlab.md
+++ b/reference/social-login-reference/gitlab.md
@@ -27,7 +27,7 @@ First, you need to register a new OAuth GitLab app. Follow the official GitLab i
 
 ![Creating an OAuth GitLab app](../../.gitbook/assets/gitlab-create-app.png)
 
-You need to add a name for your new application and the **Redirect URI**. Go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your application **** and instance and go to **Authentication -> Social Login**.  Click the **Manage connection** button under the GitLab provider and copy the **Authorized redirect URI**. Go back to the GitLab panel, paste the value into the **Redirect URI**, select any scopes that would you like your users to provide and save the application.
+You need to add a name for your new application and the **Redirect URI**. Go to the [Social Login page](https://dashboard.clerk.dev/last-active?path=authentication/social) and enable GitLab. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Go back to the GitLab panel, paste the value into the **Redirect URI**, select any scopes that would you like your users to provide and save the application.
 
 Once creation is complete, you'll get redirected to application's panel. Copy the **Application ID** and **Secret.** Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/reference/social-login-reference/hubspot.md
+++ b/reference/social-login-reference/hubspot.md
@@ -29,9 +29,9 @@ Once your app is created, click on the **Auth** tab and copy the **App Id** and 
 
 ![Configuring a HubSpot app](../../.gitbook/assets/screely-1628433157057.png)
 
-Go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your application **** and instance and go to **Authentication -> Social Login**.  Click the **Manage connection** button under the HubSpot provider and paste the values you obtained during the previous step.
+Go to the [Social Login page](https://dashboard.clerk.dev/last-active?path=authentication/social) and enable HubSpot. In the modal that opened, ensure **Use custom credentials** is enabled and paste the values you obtained during the previous step.
 
-Before you close the **Manage credentials** modal, copy the **Authorized redirect URI**. Go back to the HubSpot panel and paste it into the **Redirect URL** field and click **Save**.
+Before you close the modal, copy the **Authorized redirect URI**. Go back to the HubSpot panel and paste it into the **Redirect URL** field and click **Save**.
 
 Don't forget to click **Apply** in the Clerk dashboard. Social login with HubSpot is now configured 🔥&#x20;
 

--- a/reference/social-login-reference/linkedin.md
+++ b/reference/social-login-reference/linkedin.md
@@ -27,7 +27,7 @@ First, you need to create a new OAuth LinkedIn app.
 
 ![Creating an OAuth LinkedIn app](../../.gitbook/assets/oauth\_linkedin\_create\_app.png)
 
-You need to set a name, associate a LinkedIn page with it and finally upload a logo for your new application. Go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your application **** and instance and go to **Authentication -> Social Login**. Click the **Manage connection** button under the LinkedIn provider, copy the **Authorized redirect URI** and paste the value into the **Redirect URL**, as shown below.
+You need to set a name, associate a LinkedIn page with it and finally upload a logo for your new application. Go to the [Social Login page](https://dashboard.clerk.dev/last-active?path=authentication/social) and enable LinkedIn. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **Redirect URL**, as shown below.
 
 ![Obtaining the Application ID and Client secret](../../.gitbook/assets/oauth\_linkedin\_credentials.png)
 

--- a/reference/social-login-reference/notion.md
+++ b/reference/social-login-reference/notion.md
@@ -31,7 +31,7 @@ You need to set a name, a logo and associate a Notion workspace with it. Make su
 
 ![](../../.gitbook/assets/oauth-notion-public-integration.png)
 
-Go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your application **** and instance and go to **Authentication -> Social Login**. Click the **Manage connection** button under the Notion provider, copy the **Authorized redirect URI** and paste the value into the **Redirect URIs**, as shown below, after changing the integration type to **Public**. Fill also any other information required from Notion and click Submit.
+Go to the [Social Login page](https://dashboard.clerk.dev/last-active?path=authentication/social) and enable Notion. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **Redirect URIs**, as shown below, after changing the integration type to **Public**. Fill also any other information required from Notion and click Submit.
 
 ![Obtaining the Client ID and Client secret](../../.gitbook/assets/oauth-notion-credentials.png)
 

--- a/reference/social-login-reference/social-login-facebook.md
+++ b/reference/social-login-reference/social-login-facebook.md
@@ -35,11 +35,11 @@ Once you have a OAuth client ID created, click on the newly created ID under **O
 
 ![Retrieving the App ID and App Secret](../../.gitbook/assets/screely-1628401739107.png)
 
-Go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your application **** and instance and go to **Authentication -> Social Login**. Click the **Manage connection** button under the Facebook provider and paste the values you obtained during the previous step.
+Go to the [Social Login page](https://dashboard.clerk.dev/last-active?path=authentication/social) and enable Facebook. In the modal that opened, ensure **Use custom credentials** is enabled and paste the values you obtained during the previous step.
 
 ![Adding the Valid OAuth Redirect URI](../../.gitbook/assets/screely-1628402032599.png)
 
-Before you close the **Manage credentials** modal, copy the **Authorized redirect URI**. Go back to the Facebook dashboard, open the **Facebook Login** menu (sidebar) and click **Settings**. **** Paste the URI you copied before into the **Valid OAuth Redirect URIs** field. Hit **Save Changes**.
+Before you close the modal, copy the **Authorized redirect URI**. Go back to the Facebook dashboard, open the **Facebook Login** menu (sidebar) and click **Settings**. **** Paste the URI you copied before into the **Valid OAuth Redirect URIs** field. Hit **Save Changes**.
 
 Don't forget to click **Apply** in the Clerk dashboard. Social login with Facebook is now configured 🔥&#x20;
 

--- a/reference/social-login-reference/social-login-google.md
+++ b/reference/social-login-reference/social-login-google.md
@@ -31,9 +31,9 @@ Once you have a OAuth client ID **** created, click on the newly created ID unde
 
 ![Copying the Client ID and Client Secret](../../.gitbook/assets/screely-1628372330828.png)
 
-Go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your application **** and instance and go to **Authentication -> Social Login**.  Click the **Manage connection** button under the Google provider and paste the values you obtained during the previous step.
+Go to the [Social Login page](https://dashboard.clerk.dev/last-active?path=authentication/social) and enable Google.  In the modal that opened, ensure **Use custom credentials** is enabled and paste the values you obtained during the previous step.
 
-Before you close the **Manage credentials** modal, copy the **Authorized redirect URI.** Add it to the Google console dashboard by creating a new **Authorized redirect URI** as shown in the screenshot above.&#x20;
+Before you close the modal, copy the **Authorized redirect URI.** Add it to the Google console dashboard by creating a new **Authorized redirect URI** as shown in the screenshot above.&#x20;
 
 Don't forget to click **Apply** in the Clerk dashboard. Social login with Google is now configured 🔥&#x20;
 

--- a/reference/social-login-reference/tiktok.md
+++ b/reference/social-login-reference/tiktok.md
@@ -29,7 +29,7 @@ First, you need to create a new TikTok app. Go to the [TikTok for developers](ht
 
 Add an icon and a name for your new project and hit **Start**.&#x20;
 
-You'll get redirected to the app creation form. Notice that you need to fill the **Callback URL** and **Redirect domain** fields. Go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your application **** and instance and go to **Authentication -> Social Login**. Click the **Manage connection** button under the Github provider and copy the **Authorized redirect URI**.&#x20;
+You'll get redirected to the app creation form. Notice that you need to fill the **Callback URL** and **Redirect domain** fields. Go to the [Social Login page](https://dashboard.clerk.dev/last-active?path=authentication/social) and enable TikTok. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**.&#x20;
 
 ![Filling the Callback URL and Redirect domain fields](../../.gitbook/assets/screely-1628431072612.png)
 

--- a/reference/social-login-reference/twitch.md
+++ b/reference/social-login-reference/twitch.md
@@ -27,7 +27,7 @@ First, you need to register a new OAuth Twitch app at the [Twitch Developers Con
 
 ![](../../.gitbook/assets/twitch-create-oauth-app-1.png) ![Creating an OAuth Twitch app](../../.gitbook/assets/twitch-create-oauth-app-2.png)
 
-Set a name and the a category for your new application. You also need to add the **OAuth Redirect URLs.** Go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your application **** and instance and go to **Authentication -> Social Login**. Click the **Manage connection** button under the Twitch provider and copy the **Authorized redirect URI**. Paste the value into the **OAuth Redirect URLs** input and click create.
+Set a name and the a category for your new application. You also need to add the **OAuth Redirect URLs.** Go to the [Social Login page](https://dashboard.clerk.dev/last-active?path=authentication/social) and enable Twitch. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **OAuth Redirect URLs** input and click create.
 
 Once all the above are complete, copy the **Client ID** and **Client Secret.** Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/reference/social-login-reference/twitter.md
+++ b/reference/social-login-reference/twitter.md
@@ -27,7 +27,7 @@ If you don't have an existing Twitter Application you've set up for social login
 
 To do so, go to "[Projects & Apps](https://developer.twitter.com/en/portal/projects-and-apps)" and click "**+ Create App**" to create a new application. After entering a name, you'll be presented with your app's credentials; **API Key** and **API Secret**. Copy those values; we're going to use them in a while.
 
-Go to the [Clerk Dashboard](https://dashboard.clerk.dev), select your application **** and instance and go to **Authentication -> Social Login**. Click the **Manage connection** button under the Twitter provider, select **Custom profile** and paste the **API Key** and **API Secret** values which we copied in the previous step, into the **Consumer key** and **Consumer secret** respectively. Then, copy the **Authorized redirect URI,** we're going to need it shortly after.
+Go to the [Social Login page](https://dashboard.clerk.dev/last-active?path=authentication/social) and enable Twitter. In the modal that opened, ensure **Use custom credentials** is enabled and paste the **API Key** and **API Secret** values which we copied in the previous step, into the **API key** and **API secret key** respectively. Then, copy the **Authorized redirect URI,** we're going to need it shortly after.
 
 Navigate to your application settings screen and scroll down to the **User authentication settings** section **** and click **Set up**.
 


### PR DESCRIPTION
Added the last active redirect on dashboard links.

Also, some instructions on how to configure authentication of any sort (password, passwordless, OAuth, etc) were updated to match the new dashboard's structure, though some more changes might be needed, as I've tried to not derail too much from this PRs intention.

Notes:
- CTAs for "create a new Clerk application" weren't changed, as they're supposed to go to the dashboard's initial page
- Some instructions on how to get to a certain page or section, in both text and image formats, were deleted as the new links will bring the users straight into the desired page